### PR TITLE
refactor: migrate to GitHub Actions Pages deployment

### DIFF
--- a/.github/workflows/build-presentation.yaml
+++ b/.github/workflows/build-presentation.yaml
@@ -1,4 +1,4 @@
-name: Build Presentation
+name: Build and Deploy Presentation
 
 on:
   push:
@@ -10,4 +10,6 @@ jobs:
   build-and-deploy:
     uses: IndrajeetPatil/workflows/.github/workflows/build-presentation-r.yaml@main
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 README.html
 .DS_Store
 /.claude/
+
+# Quarto
+/.quarto/
+_site/
+_extensions/

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,0 +1,3 @@
+project:
+  type: default
+  output-dir: _site


### PR DESCRIPTION
## Summary

Migrate from branch-based deployment (`docs` branch via `JamesIves/github-pages-deploy-action`) to GitHub Actions Pages deployment (`actions/upload-pages-artifact` + `actions/deploy-pages`).

## Changes

- Update workflow permissions to `contents: read`, `pages: write`, `id-token: write`
- Add `_quarto.yml` with `output-dir: _site`
- Update `.gitignore` to ignore Quarto build artifacts (`_site/`, `_extensions/`, `.quarto/`)
- `check-link-rot.yaml` left untouched

## Prerequisites

- Merge [IndrajeetPatil/workflows#2](https://github.com/IndrajeetPatil/workflows/pull/2) first (updates the shared R workflow)

## Post-merge

- Change GitHub Pages source from 'Deploy from branch' to 'GitHub Actions' in repo settings
- Optionally delete the `docs` branch