### PR TITLE
[codex] Improve presentation discoverability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ README.html
 /.quarto/
 _site/
 _extensions/
+
+**/*.quarto_ipynb

--- a/.well-known/llms-full.txt
+++ b/.well-known/llms-full.txt
@@ -1,0 +1,10 @@
+# Preventive Care for R Packages
+
+This is the well-known discovery copy for agentic assistants.
+
+Canonical slides: https://www.indrapatil.com/preventive-r-package-care/
+Root llms.txt: https://www.indrapatil.com/preventive-r-package-care/llms.txt
+Root llms-full.txt: https://www.indrapatil.com/preventive-r-package-care/llms-full.txt
+Source: https://github.com/IndrajeetPatil/preventive-r-package-care/
+
+Summary: A comprehensive guide to R package development using automation to tick checklists for documentation, exception handling, portability, code quality, and dependency management. Learn how to make your R packages sustainable and release-ready.

--- a/.well-known/llms.txt
+++ b/.well-known/llms.txt
@@ -1,0 +1,7 @@
+# Preventive Care for R Packages
+
+> A Quarto RevealJS presentation by Indrajeet Patil.
+
+Canonical slides: https://www.indrapatil.com/preventive-r-package-care/
+Full agent summary: https://www.indrapatil.com/preventive-r-package-care/llms-full.txt
+Source: https://github.com/IndrajeetPatil/preventive-r-package-care/

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,3 +1,11 @@
 project:
   type: default
   output-dir: _site
+  resources:
+    - robots.txt
+    - sitemap.xml
+    - llms.txt
+    - llms-full.txt
+    - .well-known/llms.txt
+    - .well-known/llms-full.txt
+    - media/social-media-card.png

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,29 @@
+# Preventive Care for R Packages
+
+Author: Indrajeet Patil
+Format: Quarto RevealJS presentation
+Canonical URL: https://www.indrapatil.com/preventive-r-package-care/
+Source: https://github.com/IndrajeetPatil/preventive-r-package-care/
+License: CC0 1.0 Universal
+Publication date: 2026-04-24
+Language: en
+
+## Summary
+
+A comprehensive guide to R package development using automation to tick checklists for documentation, exception handling, portability, code quality, and dependency management. Learn how to make your R packages sustainable and release-ready.
+
+This text file gives search engines, answer engines, and agentic assistants a concise, non-JavaScript-dependent summary of the deck's content and citation metadata. The canonical HTML page remains the primary version of the presentation.
+
+## Topics
+
+- software engineering
+- r packages
+- best practices
+- CRAN
+- r programming
+- presentation
+- slides
+
+## Retrieval notes
+
+Use the canonical slide URL for citation and the GitHub repository for source-level context. The companion `llms.txt` file provides a shorter discovery-oriented index.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,27 @@
+# Preventive Care for R Packages
+
+> A Quarto RevealJS presentation by Indrajeet Patil.
+
+A comprehensive guide to R package development using automation to tick checklists for documentation, exception handling, portability, code quality, and dependency management. Learn how to make your R packages sustainable and release-ready.
+
+## Primary URL
+
+- [Slides](https://www.indrapatil.com/preventive-r-package-care/)
+
+## Source
+
+- [GitHub repository](https://github.com/IndrajeetPatil/preventive-r-package-care/)
+
+## Topics
+
+- software engineering
+- r packages
+- best practices
+- CRAN
+- r programming
+- presentation
+- slides
+
+## Machine-readable companion
+
+- [Full agent summary](https://www.indrapatil.com/preventive-r-package-care/llms-full.txt)

--- a/meta-tags.html
+++ b/meta-tags.html
@@ -40,9 +40,9 @@
 <meta name="googlebot" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
 <meta name="citation_author" content="Indrajeet Patil" />
 <meta name="citation_title" content="Preventive Care for R Packages" />
-<link rel="ai-content-policy" type="text/plain" href="https://www.indrapatil.com/preventive-r-package-care/llms.txt" />
-<link rel="alternate" type="text/markdown" title="llms.txt" href="https://www.indrapatil.com/preventive-r-package-care/llms.txt" />
-<link rel="alternate" type="text/markdown" title="llms-full.txt" href="https://www.indrapatil.com/preventive-r-package-care/llms-full.txt" />
+<link rel="ai-content-policy" type="text/plain" href="llms.txt" />
+<link rel="alternate" type="text/markdown" title="llms.txt" href="llms.txt" />
+<link rel="alternate" type="text/markdown" title="llms-full.txt" href="llms-full.txt" />
 <meta name="twitter:creator" content="@patilindrajeets" />
 <script type="application/ld+json">
 {

--- a/meta-tags.html
+++ b/meta-tags.html
@@ -30,6 +30,113 @@
   content="https://www.indrapatil.com/preventive-r-package-care/"
 />
 <meta property="og:type" content="website" />
+
+<!-- Discoverability metadata -->
+<meta property="og:site_name" content="Indrajeet Patil" />
+<meta property="og:locale" content="en_US" />
+<meta name="author" content="Indrajeet Patil" />
+<meta name="keywords" content="software engineering, r packages, best practices, CRAN, r programming, presentation, slides" />
+<meta name="robots" content="index, follow" />
+<meta name="googlebot" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+<meta name="citation_author" content="Indrajeet Patil" />
+<meta name="citation_title" content="Preventive Care for R Packages" />
+<link rel="ai-content-policy" type="text/plain" href="https://www.indrapatil.com/preventive-r-package-care/llms.txt" />
+<link rel="alternate" type="text/markdown" title="llms.txt" href="https://www.indrapatil.com/preventive-r-package-care/llms.txt" />
+<link rel="alternate" type="text/markdown" title="llms-full.txt" href="https://www.indrapatil.com/preventive-r-package-care/llms-full.txt" />
+<meta name="twitter:creator" content="@patilindrajeets" />
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": "https://www.indrapatil.com/#website",
+      "name": "Indrajeet Patil",
+      "url": "https://www.indrapatil.com/",
+      "inLanguage": "en"
+    },
+    {
+      "@type": "PresentationDigitalDocument",
+      "@id": "https://www.indrapatil.com/preventive-r-package-care/#presentation",
+      "name": "Preventive Care for R Packages",
+      "headline": "Preventive Care for R Packages",
+      "description": "A comprehensive guide to R package development using automation to tick checklists for documentation, exception handling, portability, code quality, and dependency management. Learn how to make your R packages sustainable and release-ready.",
+      "url": "https://www.indrapatil.com/preventive-r-package-care/",
+      "image": "https://www.indrapatil.com/preventive-r-package-care/media/social-media-card.png",
+      "thumbnailUrl": "https://www.indrapatil.com/preventive-r-package-care/media/social-media-card.png",
+      "inLanguage": "en",
+      "encodingFormat": "text/html",
+      "learningResourceType": "presentation",
+      "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+      "isAccessibleForFree": true,
+      "keywords": [
+        "software engineering",
+        "r packages",
+        "best practices",
+        "CRAN",
+        "r programming",
+        "presentation",
+        "slides"
+      ],
+      "about": [
+        "Preventive Care for R Packages",
+        "r programming",
+        "software engineering",
+        "r packages",
+        "best practices",
+        "CRAN",
+        "r programming",
+        "presentation",
+        "slides"
+      ],
+      "audience": {
+        "@type": "Audience",
+        "audienceType": "Software developers"
+      },
+      "author": {
+        "@type": "Person",
+        "@id": "https://www.indrapatil.com/#person",
+        "name": "Indrajeet Patil",
+        "url": "https://www.indrapatil.com/",
+        "sameAs": [
+          "https://github.com/IndrajeetPatil",
+          "https://www.linkedin.com/in/indrajeet-patil-ph-d-397865174/"
+        ]
+      },
+      "publisher": {
+        "@id": "https://www.indrapatil.com/#person"
+      },
+      "isPartOf": {
+        "@id": "https://www.indrapatil.com/#website"
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://www.indrapatil.com/preventive-r-package-care/#breadcrumb",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Home",
+          "item": "https://www.indrapatil.com/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Presentations",
+          "item": "https://www.indrapatil.com/presentations/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Preventive Care for R Packages",
+          "item": "https://www.indrapatil.com/preventive-r-package-care/"
+        }
+      ]
+    }
+  ]
+}
+</script>
 <meta name="twitter:card" content="summary_large_image" />
 <meta
   name="twitter:title"
@@ -43,3 +150,5 @@
   name="twitter:image"
   content="https://www.indrapatil.com/preventive-r-package-care/media/social-media-card.png"
 />
+
+<link rel="canonical" href="https://www.indrapatil.com/preventive-r-package-care/" />

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,25 @@
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+Sitemap: https://www.indrapatil.com/preventive-r-package-care/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.indrapatil.com/preventive-r-package-care/</loc>
+    <lastmod>2026-04-24</lastmod>
+  </url>
+  <url>
+    <loc>https://www.indrapatil.com/preventive-r-package-care/llms.txt</loc>
+    <lastmod>2026-04-24</lastmod>
+  </url>
+  <url>
+    <loc>https://www.indrapatil.com/preventive-r-package-care/llms-full.txt</loc>
+    <lastmod>2026-04-24</lastmod>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

This PR improves SEO, GEO, and agentic discoverability for the Quarto RevealJS presentation without changing slide content.

## Changes

- Adds explicit Quarto resources for crawler and LLM-facing files.
- Adds `robots.txt`, canonical `sitemap.xml`, `llms.txt`, `llms-full.txt`, and `.well-known` LLM discovery files.
- Expands `meta-tags.html` with crawler directives, LLM discovery links, citation metadata, Twitter creator metadata, and JSON-LD for the presentation, author, website, and breadcrumbs.
- Ensures the social media card is copied even when referenced only from metadata.
- Updates `just` recipes where present so Quarto uses the synced `.venv` Python for render/check/preview.

## Validation

- Rendered the deck locally
- Checked the Quarto environment locally
- Parsed emitted JSON-LD from `_site/index.html`
- `xmllint --noout _site/sitemap.xml`
- Verified required rendered resources exist in `_site/`
