### PR TITLE
fix: address PR reviews for just open and copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # GitHub Copilot Instructions
 
-(This file mirrors AGENTS.md)
+(This file is based on AGENTS.md)
 
 Guidance for AI coding agents working on this repository.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,6 @@
-# AGENTS.md
+# GitHub Copilot Instructions
+
+(This file mirrors AGENTS.md)
 
 Guidance for AI coding agents working on this repository.
 

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ help:
     @echo "  just install       - Install R dependencies from DESCRIPTION"
     @echo "  just render        - Render the Quarto slides to HTML"
     @echo "  just preview       - Start Quarto preview with live reload"
-    @echo "  just open          - Alias for preview (live reload dev server)"
+    @echo "  just open          - Alias for preview (live-reload dev server)"
     @echo "  just clean         - Remove generated files and caches"
     @echo "  just check         - Check Quarto and R version setup"
     @echo "  just (default)     - Install dependencies and start live-reload preview"

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ help:
     @echo "  just install       - Install R dependencies from DESCRIPTION"
     @echo "  just render        - Render the Quarto slides to HTML"
     @echo "  just preview       - Start Quarto preview with live reload"
-    @echo "  just open          - Alias for preview (live reload, Chrome-safe)"
+    @echo "  just open          - Alias for preview (live reload dev server)"
     @echo "  just clean         - Remove generated files and caches"
     @echo "  just check         - Check Quarto and R version setup"
     @echo "  just (default)     - Install dependencies and start live-reload preview"


### PR DESCRIPTION
This PR addresses review comments from the previous PR:
1. Removed 'Chrome-safe' from `justfile` help text.
2. Renamed heading in `.github/copilot-instructions.md`.